### PR TITLE
rdf-spec is a development dependency

### DIFF
--- a/rdf-reasoner.gemspec
+++ b/rdf-reasoner.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency     'rdf-vocab',       '~> 2.0'
   gem.add_runtime_dependency     'rdf-xsd',         '~> 2.0'
 
-  gem.add_runtime_dependency     'rdf-spec',        '~> 2.0'
+  gem.add_development_dependency 'rdf-spec',        '~> 2.0'
   gem.add_development_dependency 'json-ld',         '~> 2.0'
   gem.add_development_dependency 'rdf-turtle',      '~> 2.0'
   gem.add_development_dependency 'equivalent-xml',  '~> 0.4'


### PR DESCRIPTION
This is causing problems like:
```
  In snapshot (Gemfile.lock):
    webmock (= 2.1.0)

  In Gemfile:
    webmock

    active-fedora (= 11.0.0.rc3) was resolved to 11.0.0.rc3, which depends on
      active-triples (~> 0.10.0) was resolved to 0.10.0, which depends on
        linkeddata (~> 2.0) was resolved to 2.0.0, which depends on
          rdf-reasoner (~> 0.4) was resolved to 0.4.0, which depends on
            rdf-spec (~> 2.0) was resolved to 2.0.0, which depends on
              webmock (~> 1.17)
```